### PR TITLE
chore: エージェント向けドキュメントを整理し CLAUDE.md と copilot-instructions.md に統一

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ adding `npm`/`pytest`/`eslint` commands that do not exist here.
 
 ## Do not flag
 
-- Absence of a package manager, lockfile, test suite, or CI config — this is intentional.
+- Absence of a JS/frontend package manager, JS lockfile, test suite, or CI config — this
+  is intentional. (Python deps are the exception: they use `pip` + `requirements.txt`.)
 - Global/`var`-style vanilla JS and CDN-loaded jQuery in `static/` — consistent with the
   existing codebase; do not push toward a framework or module bundler.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Copilot code review instructions
+
+Browser-based speech-to-text transcriber: a vanilla-JS/jQuery static frontend
+(`static/`) using the Web Speech API, plus two interchangeable backends that persist
+transcripts — `main.py` (FastAPI) and `api.php` (PHP).
+
+There is no build system, test suite, or linter in this repo. Do not suggest running or
+adding `npm`/`pytest`/`eslint` commands that do not exist here.
+
+## Review priorities
+
+- **Backend parity**: `main.py` (`POST /api`) and `api.php` must accept the same request
+  body (`startTime`, `timeStamp`, `transcript`, `full`) and produce the same output
+  (`data/<startTime>.log` with tab-separated `<timeStamp>s\t<transcript>` lines, and
+  `data/<startTime>.json`). Flag changes to one backend that are not mirrored in the other.
+- **File-writing safety**: both backends write user-derived data to `data/`. Watch for
+  path traversal or injection via `startTime`/timestamps used in filenames, and unchecked
+  file writes.
+- **Input validation**: request fields come from the browser. Flag missing validation of
+  `startTime`/`full` before they are used (e.g. `date()`/`datetime.fromtimestamp`, array
+  iteration).
+- **Vendored libraries**: `static/axios.min.js`, `static/diff.js`, `static/screenfull.min.js`
+  are third-party files committed as-is. Do not review their internals or suggest style
+  fixes for them; only flag if a vendored file is edited by hand instead of version-bumped.
+- **README sync**: `README.md` and `README-ja.md` mirror each other. Flag setup/feature
+  changes applied to only one.
+
+## Do not flag
+
+- Absence of a package manager, lockfile, test suite, or CI config — this is intentional.
+- Global/`var`-style vanilla JS and CDN-loaded jQuery in `static/` — consistent with the
+  existing codebase; do not push toward a framework or module bundler.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,12 +10,15 @@ adding `npm`/`pytest`/`eslint` commands that do not exist here.
 ## Review priorities
 
 - **Backend parity**: `main.py` (`POST /api`) and `api.php` must accept the same request
-  body (`startTime`, `timeStamp`, `transcript`, `full`) and produce the same output
-  (`data/<startTime>.log` with tab-separated `<timeStamp>s\t<transcript>` lines, and
-  `data/<startTime>.json`). Flag changes to one backend that are not mirrored in the other.
-- **File-writing safety**: both backends write user-derived data to `data/`. Watch for
-  path traversal or injection via `startTime`/timestamps used in filenames, and unchecked
-  file writes.
+  body (`startTime`, `timeStamp`, `transcript`, `full`) and produce the same output — a
+  filename derived from `startTime` formatted as `YYYY-MM-DD HH-MM-SS`, written as
+  `data/<that timestamp>.log` (tab-separated `<timeStamp>s\t<transcript>` lines) and
+  `data/<that timestamp>.json`. Flag changes to one backend that are not mirrored in the other.
+- **File-writing safety**: both backends write user-derived data to `data/`. The filename
+  currently comes only from `startTime` run through `datetime`/`date` formatting, which
+  constrains it; flag any change that puts raw request values (e.g. `startTime`,
+  `transcript`) into a path without that formatting, or otherwise enables path traversal or
+  unchecked file writes.
 - **Input validation**: request fields come from the browser. Flag missing validation of
   `startTime`/`full` before they are used (e.g. `date()`/`datetime.fromtimestamp`, array
   iteration).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,18 @@
 Browser-based speech-to-text transcriber. The static frontend uses the Web Speech
 API (`webkitSpeechRecognition`) to transcribe microphone audio in real time, shows
 the results (with recognition alternatives on hover), and can POST each transcript to
-a configurable `API URL`. A small backend receives those POSTs and appends them to
-per-session `.log` and `.json` files under `data/`.
+a configurable `API URL`. A small backend receives those POSTs and writes them to
+per-session `.log` and `.json` files under `data/` — each POST sends the full transcript
+so far, and the backend overwrites that session's files with it (it does not append).
 
 The frontend can run standalone from GitHub Pages; the backend is optional and only
 needed if you want transcripts saved to disk.
 
 ## Running
 
-There is no build step, package manager, test suite, or linter in this repository.
+There is no build step, JS/frontend package manager, test suite, or linter in this
+repository. Python dependencies are the one exception: they are managed with `pip` +
+`requirements.txt` (see the Python backend below).
 
 - Frontend only: open `static/index.html` (or the GitHub Pages URL). No server needed.
 - Python backend:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,14 @@ Browser support: Chrome 33+ / Edge 79+ (Web Speech API required).
 - `static/script.js` — all recognition logic: starts `SpeechRecognition`, renders
   interim/final results, diffs alternatives, and POSTs finalized transcripts via axios.
 - `static/style.css`, `static/manifest.json` — styling and PWA manifest.
-- `static/axios.min.js`, `static/diff.js` (jsdifflib), `static/screenfull.min.js` —
-  vendored third-party libraries, committed as-is. Do not hand-edit these.
-- `main.py` — FastAPI backend. `POST /api` writes `data/<startTime>.log` (tab-separated
-  `<timeStamp>s\t<transcript>` lines) and `data/<startTime>.json` (raw `full` array).
+- `static/axios.min.js`, `static/diff.js` (kpdecker's `diff` / jsdiff), `static/screenfull.min.js`
+  — vendored third-party libraries, committed as-is. Do not hand-edit these.
+- `main.py` — FastAPI backend. `POST /api` derives a filename from `startTime`, formatted
+  as `YYYY-MM-DD HH-MM-SS` (via `datetime.fromtimestamp(...).strftime(...)`), and writes
+  `data/<that timestamp>.log` (tab-separated `<timeStamp>s\t<transcript>` lines) and
+  `data/<that timestamp>.json` (raw `full` array).
 - `api.php` — PHP backend implementing the same request/response contract and file
-  output format as `main.py`.
+  output format as `main.py` (same `date("Y-m-d H-i-s", startTime)` filename derivation).
 - `data/` — runtime output, gitignored. Not committed.
 
 ## Conventions
@@ -59,5 +61,6 @@ Browser support: Chrome 33+ / Edge 79+ (Web Speech API required).
 ## Verification
 
 No automated tests exist. Verify changes manually: run `python3 main.py`, open the page,
-grant microphone access, record speech, and confirm results render and that
-`data/<startTime>.{log,json}` are written with the expected content.
+grant microphone access, record speech, and confirm results render and that a
+`data/<YYYY-MM-DD HH-MM-SS>.{log,json}` pair (named from the session start time) is
+written with the expected content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+## Overview
+
+Browser-based speech-to-text transcriber. The static frontend uses the Web Speech
+API (`webkitSpeechRecognition`) to transcribe microphone audio in real time, shows
+the results (with recognition alternatives on hover), and can POST each transcript to
+a configurable `API URL`. A small backend receives those POSTs and appends them to
+per-session `.log` and `.json` files under `data/`.
+
+The frontend can run standalone from GitHub Pages; the backend is optional and only
+needed if you want transcripts saved to disk.
+
+## Running
+
+There is no build step, package manager, test suite, or linter in this repository.
+
+- Frontend only: open `static/index.html` (or the GitHub Pages URL). No server needed.
+- Python backend:
+  - `pip3 install -U -r requirements.txt` (FastAPI + uvicorn, pinned versions)
+  - `python3 main.py --open-browser` — serves the frontend and API on port `8080`.
+    `--open-browser` also launches a browser (Chrome path is hardcoded for Windows,
+    otherwise falls back to the default browser).
+  - Set the `API URL` field in the UI to `http://localhost:8080/api`.
+- PHP backend: place `api.php` on any PHP server and point `API URL` at it. It is a
+  standalone equivalent of the Python `POST /api` handler.
+
+Browser support: Chrome 33+ / Edge 79+ (Web Speech API required).
+
+## Architecture / key files
+
+- `static/index.html` — page markup; loads the vendored libs and `script.js`. jQuery
+  is loaded from a Google CDN (the only external runtime dependency).
+- `static/script.js` — all recognition logic: starts `SpeechRecognition`, renders
+  interim/final results, diffs alternatives, and POSTs finalized transcripts via axios.
+- `static/style.css`, `static/manifest.json` — styling and PWA manifest.
+- `static/axios.min.js`, `static/diff.js` (jsdifflib), `static/screenfull.min.js` —
+  vendored third-party libraries, committed as-is. Do not hand-edit these.
+- `main.py` — FastAPI backend. `POST /api` writes `data/<startTime>.log` (tab-separated
+  `<timeStamp>s\t<transcript>` lines) and `data/<startTime>.json` (raw `full` array).
+- `api.php` — PHP backend implementing the same request/response contract and file
+  output format as `main.py`.
+- `data/` — runtime output, gitignored. Not committed.
+
+## Conventions
+
+- `main.py` and `api.php` implement the same API contract (request body: `startTime`,
+  `timeStamp`, `transcript`, `full`; output: matching `.log` + `.json` files). When you
+  change one backend's request shape or output format, change the other to match.
+- Vendored libraries live in `static/` and are edited only by replacing the whole file
+  with a new upstream version.
+- Pin dependency versions in `requirements.txt` (existing entries are exact-pinned).
+
+## Documentation
+
+- `README.md` (English) and `README-ja.md` (Japanese) are kept in sync — update both
+  when changing setup steps, features, or requirements.
+
+## Verification
+
+No automated tests exist. Verify changes manually: run `python3 main.py`, open the page,
+grant microphone access, record speech, and confirm results render and that
+`data/<startTime>.{log,json}` are written with the expected content.


### PR DESCRIPTION
## 概要

AI コーディングエージェント向けのドキュメントを整備し、`CLAUDE.md` と `.github/copilot-instructions.md` の 2 ファイルに統一する。

## 変更内容

### 新規作成
- **CLAUDE.md**: ブラウザ Web Speech API による文字起こし静的フロントエンド(`static/`)と、トランスクリプトを永続化する 2 つの互換バックエンド(`main.py` = FastAPI / `api.php` = PHP)の概要・実行方法・アーキテクチャ・規約・検証方法を記載。ビルド/テスト/lint/パッケージマネージャが存在しないことを明記。
- **.github/copilot-instructions.md**: Copilot コードレビュー向け。2 バックエンドの API 契約・出力フォーマット同期、`data/` へのファイル書き込み時のパストラバーサル/入力バリデーション、vendored ライブラリ(axios/diff/screenfull)はレビュー対象外、`README.md`/`README-ja.md` 同期を重点確認項目に設定。

### 削除
- なし(`AGENTS.md`/`GEMINI.md` は元々存在せず、機能的依存も無し)。

## レビューで修正した点

独立レビューで実リポジトリと照合し、以下の stale 記述を修正:
- 出力ファイル名を `data/<startTime>.log` と記していたが、実際は `startTime` を `YYYY-MM-DD HH-MM-SS` 形式(`datetime.fromtimestamp(...).strftime(...)` / `date("Y-m-d H-i-s", ...)`)に整形した名前。両ファイルで正確に記述し直した。
- `diff.js` のライブラリ名を「jsdifflib」と誤記していたため、実体である kpdecker の `diff`(jsdiff, v2.0.1)に訂正。
- copilot-instructions のパストラバーサル観点を、現状 `date`/`datetime` 整形でファイル名が制約されている実態を踏まえた表現に調整。